### PR TITLE
docs: add framework reference cross-link

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,3 +137,7 @@ This tool supports:
 - Command-line arguments (argparse)
 - Detect specific attack patterns
 
+
+## Framework Reference
+
+Control family mappings and AWS implementation details are documented in [nist-800-53-rev-5-to-aws-mapping](https://github.com/0xBahalaNa/nist-800-53-rev-5-to-aws-mapping).


### PR DESCRIPTION
## Summary
- Add framework reference section linking to nist-800-53-rev-5-to-aws-mapping repo

## Test plan
- [x] Link resolves to correct repo

Closes #11 (nist-800-53-rev-5-to-aws-mapping)